### PR TITLE
fix(event): on[upper]* for event name syntax

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,7 @@ export default function (CustomElement, opts) {
           return;
         }
 
-        if (name.indexOf('on') === 0) {
+        if (name.indexOf('on') === 0 && name[2] === name[2].toUpperCase()) {
           syncEvent(node, name.substring(2), props[name]);
         } else {
           node[name] = props[name];

--- a/test/unit/events.js
+++ b/test/unit/events.js
@@ -34,7 +34,7 @@ describe('custom events', () => {
         },
       }),
     }), { React, ReactDOM });
-    const comp = ReactDOM.render(<Comp ontest={() => count++} />, window.fixture);
+    const comp = ReactDOM.render(<Comp onTest={() => count++} />, window.fixture);
 
     setTimeout(() => {
       ReactDOM.findDOMNode(comp).trigger();
@@ -58,6 +58,7 @@ describe('custom events', () => {
     const func = () => ++count;
 
     // Using both ontest and onTest (case-sensitive) test case-sensitivity.
+    // ontest should be just a normal prop
     const comp = ReactDOM.render(<Comp ontest={func} onTest={func} />, window.fixture);
 
     setTimeout(() => {
@@ -109,6 +110,29 @@ describe('custom events', () => {
     setTimeout(() => {
       ReactDOM.findDOMNode(comp).trigger();
       expect(count).to.equal(1);
+      done();
+    }, 1);
+  });
+
+  it('should not treat `once` prop as an event', done => {
+    let count = 0;
+    const Comp = reactify(document.registerElement('x-custom-event-6', {
+      prototype: Object.create(HTMLElement.prototype, {
+        trigger: {
+          value() {
+            this.dispatchEvent(new CustomEvent('ce'));
+          },
+        },
+      }),
+    }), { React, ReactDOM });
+
+    const func = () => ++count;
+
+    const comp = ReactDOM.render(<Comp once={func} />, window.fixture);
+
+    setTimeout(() => {
+      ReactDOM.findDOMNode(comp).trigger();
+      expect(count).to.equal(0);
       done();
     }, 1);
   });

--- a/test/unit/props.js
+++ b/test/unit/props.js
@@ -38,7 +38,7 @@ describe('props', () => {
     const elem = window.fixture.firstChild;
     expect(elem.getAttribute('class')).to.equal('test');
   });
-  
+
   it('should not set children', () => {
     const Comp = createComponentWithProp('children', () => { throw new Error('set children'); });
     ReactDOM.render(<Comp><div /></Comp>, window.fixture);
@@ -46,7 +46,7 @@ describe('props', () => {
 
   it('should not set events', () => {
     const Comp = createComponentWithProp('oncustomevent', () => { throw new Error('set oncustomevent'); });
-    ReactDOM.render(<Comp oncustomevent="test" />, window.fixture);
+    ReactDOM.render(<Comp onCustomevent="test" />, window.fixture);
   });
 
   it('should not set attributes', () => {


### PR DESCRIPTION
BREAKING CHANGE: all small letter like `onevent` is not supported anymore. In react this is ambiguous. React is using camelCase for event names.

Fixes #30