### PR TITLE
#41 - Fix issue causing getters to be invoked when copying over to the React component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,10 +69,8 @@ export default function (CustomElement, opts) {
   }
 
   const proto = CustomElement.prototype;
-  Object.keys(proto).forEach(prop => {
-    if (typeof proto[prop] === 'function') {
-      ReactComponent.prototype[prop] = proto[prop].bind(proto);
-    }
+  Object.getOwnPropertyNames(proto).forEach(prop => {
+    Object.defineProperty(ReactComponent.prototype, prop, Object.getOwnPropertyDescriptor(proto, prop));
   });
 
   return ReactComponent;

--- a/src/index.js
+++ b/src/index.js
@@ -66,9 +66,9 @@ export default function (CustomElement, opts) {
     render() {
       return React.createElement(tagName, { style: this.props.style }, this.props.children);
     }
-  };
+  }
 
-  const proto = CustomElement.prototype
+  const proto = CustomElement.prototype;
   Object.keys(proto).forEach(prop => {
     if (typeof proto[prop] === 'function') {
       ReactComponent.prototype[prop] = proto[prop].bind(proto);

--- a/test/unit/webcomponent-proto-funcs.js
+++ b/test/unit/webcomponent-proto-funcs.js
@@ -38,7 +38,10 @@ describe('Webcomponent prototype functions', () => {
   });
 
   it('should not invoke getters', () => {
+    // If this functionality fails, calling createComponent() should cause the error to be thrown.
     const Comp = createComponent();
+
+    // We expect it to throw here to make sure we've written our test correctly.
     expect(() => Comp.prototype.getter).to.throw();
   });
 });

--- a/test/unit/webcomponent-proto-funcs.js
+++ b/test/unit/webcomponent-proto-funcs.js
@@ -1,32 +1,44 @@
 import reactify from '../../src/index';
-import React from 'react';
-import ReactDOM from 'react-dom';
 
 let x = 0;
 function createComponent() {
-  const proto = Object.create(HTMLElement.prototype);
-  proto.prop = 'prop';
-  proto.foo = function() {
-    return 'bar';
-  };
-  proto.getProp = function() {
-    return this.prop;
-  };
   return reactify(document.registerElement(`x-webcomponent-proto-funcs-${x++}`, {
-    prototype: proto,
-  }), { React, ReactDOM });
+    prototype: Object.create(HTMLElement.prototype, {
+      prop: {
+        value: 'prop',
+      },
+      foo: {
+        value() {
+          return 'bar';
+        },
+      },
+      getProp: {
+        value() {
+          return this.prop;
+        },
+      },
+      getter: {
+        get() {
+          throw new Error('should not throw when reactifying');
+        },
+      },
+    }),
+  }));
 }
 
 describe('Webcomponent prototype functions', () => {
   it('should be callable on React component', () => {
     const Comp = createComponent();
-
     expect(Comp.prototype.foo()).to.equal('bar');
   });
 
   it('should return prop', () => {
     const Comp = createComponent();
-
     expect(Comp.prototype.getProp()).to.equal('prop');
+  });
+
+  it('should not invoke getters', () => {
+    const Comp = createComponent();
+    expect(() => Comp.prototype.getter).to.throw();
   });
 });


### PR DESCRIPTION
Also fixed to copy over non-enumerable properties.

Fixes #41