### PR TITLE
Assign options to empty object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ function syncEvent(node, eventName, newEventHandler) {
 }
 
 export default function (CustomElement, opts) {
-  opts = assign(defaults, opts);
+  opts = assign({}, defaults, opts);
   const tagName = (new CustomElement()).tagName;
   const displayName = pascalCase(tagName);
   const { React, ReactDOM } = opts;

--- a/test/unit/errors.js
+++ b/test/unit/errors.js
@@ -5,9 +5,11 @@ describe('prop-types', () => {
 
   it('no react', () => {
     expect(() => reactify(document.registerElement('x-errors-1'), { React: null })).to.throw(msg);
+    expect(() => reactify(document.registerElement('x-no-errors-1'))).to.not.throw(msg);
   });
 
   it('no react-dom', () => {
     expect(() => reactify(document.registerElement('x-errors-2'), { ReactDOM: null })).to.throw(msg);
+    expect(() => reactify(document.registerElement('x-no-errors-2'))).to.not.throw(msg);
   });
 });


### PR DESCRIPTION
In case https://github.com/webcomponents/react-integration/issues/43 is considered, this would change `Object.assign` to assign options to a new Object.