### PR TITLE
#47 enable propTypes setter on returned component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,12 +43,6 @@ export default function (CustomElement, opts) {
     static get displayName() {
       return displayName;
     }
-    static get propTypes() {
-      return {
-        children: React.PropTypes.any,
-        style: React.PropTypes.any,
-      };
-    }
     componentDidMount() {
       this.componentWillReceiveProps(this.props);
     }

--- a/test/unit/prop-types.js
+++ b/test/unit/prop-types.js
@@ -3,8 +3,11 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 describe('prop-types', () => {
-  it('children', () => {
+  it('accepts propTypes', () => {
     const Comp = reactify(document.registerElement('x-prop-types-1'), { React, ReactDOM });
-    expect(Comp.propTypes.children).to.equal(React.PropTypes.any);
+    Comp.propTypes = {
+      someRequiredAttr: React.PropTypes.string
+    };
+    expect(Comp.propTypes.someRequiredAttr).to.equal(React.PropTypes.string);
   });
 });


### PR DESCRIPTION
The React component returned by reactify doesn't support setting of propTypes, which breaks the expected React API. Trying to set propTypes on the Component it returns throws a runtime error:

```
const ReactComponent = reactify(MyWebComponent);

ReactComponent.propTypes = {
  foo: React.PropTypes.string
};

//=> TypeError: Cannot set property propTypes of function ReactComponent() {
		      _classCallCheck(this, ReactComponent);
		
		      return _possibleConstructorR...<omitted>... } which has only a getter
```

This changes just adds a setter method that uses Object.assign under the hood to apply propTypes passed in to the default propTypes that were being defined already.
