### PR TITLE
fix: provide better error message if the contructor passed is not valid

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,9 @@ function syncEvent(node, eventName, newEventHandler) {
 
 export default function (CustomElement, opts) {
   opts = assign({}, defaults, opts);
+  if (typeof CustomElement !== 'function') {
+    throw new Error('Given element is not a valid constructor');
+  }
   const tagName = (new CustomElement()).tagName;
   const displayName = pascalCase(tagName);
   const { React, ReactDOM } = opts;

--- a/test/unit/errors.js
+++ b/test/unit/errors.js
@@ -3,6 +3,10 @@ import reactify from '../../src/index';
 describe('prop-types', () => {
   const msg = 'or passed via opts.';
 
+  it('no custom element', () => {
+      expect(() => reactify()).to.throw('Given element is not a valid constructor');
+  });
+
   it('no react', () => {
     expect(() => reactify(document.registerElement('x-errors-1'), { React: null })).to.throw(msg);
     expect(() => reactify(document.registerElement('x-no-errors-1'))).to.not.throw(msg);


### PR DESCRIPTION
Currently the error message thrown is quite cryptic when an invalid constructor is passed to reactify.